### PR TITLE
Add a common util function to deserialize without the recursion limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,13 @@ authors = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-description = "The Matter Labs compilers common constants"
+description = "Shared constants of the compilers for EraVM"
 
 [lib]
 doctest = false
+
+[dependencies]
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = [ "arbitrary_precision", "unbounded_depth" ] }
+serde_stacker = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub(crate) mod byte_length;
 pub(crate) mod eravm;
 pub(crate) mod exit_code;
 pub(crate) mod extension;
+pub(crate) mod utils;
 
 pub use self::base::*;
 pub use self::bit_length::*;
@@ -15,3 +16,4 @@ pub use self::byte_length::*;
 pub use self::eravm::address::*;
 pub use self::exit_code::*;
 pub use self::extension::*;
+pub use self::utils::*;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,3 +17,19 @@ where
     let result = O::deserialize(deserializer)?;
     Ok(result)
 }
+
+///
+/// Deserializes a `serde_json` object from string with the recursion limit disabled.
+///
+/// Must be used for all JSON I/O to avoid crashes due to the aforementioned limit.
+///
+pub fn deserialize_from_str<O>(input: &str) -> anyhow::Result<O>
+where
+    O: serde::de::DeserializeOwned,
+{
+    let mut deserializer = serde_json::Deserializer::from_str(input);
+    deserializer.disable_recursion_limit();
+    let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
+    let result = O::deserialize(deserializer)?;
+    Ok(result)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,19 @@
+//!
+//! The compiler common utils.
+//!
+
+///
+/// Deserializes a `serde_json` object from slice with the recursion limit disabled.
+///
+/// Must be used for all JSON I/O to avoid crashes due to the aforementioned limit.
+///
+pub fn deserialize_from_slice<O>(input: &[u8]) -> anyhow::Result<O>
+where
+    O: serde::de::DeserializeOwned,
+{
+    let mut deserializer = serde_json::Deserializer::from_slice(input);
+    deserializer.disable_recursion_limit();
+    let deserializer = serde_stacker::Deserializer::new(&mut deserializer);
+    let result = O::deserialize(deserializer)?;
+    Ok(result)
+}


### PR DESCRIPTION
# What ❔

This PR adds a common util function to deserialize JSONs without the recursion limit.

## Why ❔

Our compilers crash with the default deserialization function because they use the default recursion limit.
Usually, the JSON data passed between the compilers has very deep nesting and requires unbounded recursion depth.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
