### PR TITLE
Support code area const array simulations

### DIFF
--- a/src/eravm/address.rs
+++ b/src/eravm/address.rs
@@ -91,3 +91,15 @@ pub const ERAVM_ADDRESS_ACTIVE_PTR_DATA_COPY: u16 = 0xFFE3;
 
 /// The corresponding simulation predefined address.
 pub const ERAVM_ADDRESS_ACTIVE_PTR_DATA_SIZE: u16 = 0xFFE2;
+
+/// The corresponding simulation predefined address.
+pub const ERAVM_ADDRESS_CONST_ARRAY_DECLARE: u16 = 0xFFE1;
+
+/// The corresponding simulation predefined address.
+pub const ERAVM_ADDRESS_CONST_ARRAY_SET: u16 = 0xFFE0;
+
+/// The corresponding simulation predefined address.
+pub const ERAVM_ADDRESS_CONST_ARRAY_FINALIZE: u16 = 0xFFDF;
+
+/// The corresponding simulation predefined address.
+pub const ERAVM_ADDRESS_CONST_ARRAY_GET: u16 = 0xFFDE;


### PR DESCRIPTION
# What ❔

Adds special call instruction substitutions to manipulate arrays in code section of EraVM without Yul extensions.

## Why ❔

These functions are needed to optimize EcAdd and EcMul precompiles.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
