### PR TITLE
Add copying decommit return data to active pointer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-common"
-version = "1.3.3"
+version = "1.5.0"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]

--- a/src/eravm/address.rs
+++ b/src/eravm/address.rs
@@ -108,7 +108,10 @@ pub const ERAVM_ADDRESS_CONST_ARRAY_GET: u16 = 0xFFDE;
 pub const ERAVM_ADDRESS_DECOMMIT: u16 = 0xFFDD;
 
 /// The corresponding simulation predefined address.
-pub const ERAVM_ADDRESS_TRANSIENT_STORAGE_LOAD: u16 = 0xFFDC;
+pub const ERAVM_ADDRESS_ACTIVE_PTR_LOAD_DECOMMIT: u16 = 0xFFDC;
 
 /// The corresponding simulation predefined address.
-pub const ERAVM_ADDRESS_TRANSIENT_STORAGE_STORE: u16 = 0xFFDB;
+pub const ERAVM_ADDRESS_TRANSIENT_STORAGE_LOAD: u16 = 0xFFDB;
+
+/// The corresponding simulation predefined address.
+pub const ERAVM_ADDRESS_TRANSIENT_STORAGE_STORE: u16 = 0xFFDA;


### PR DESCRIPTION
# What ❔

Adds a call simulation to copy the decommit return data pointer to the active one.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
