### PR TITLE
Remove transient storage simulations

### DIFF
--- a/src/eravm/address.rs
+++ b/src/eravm/address.rs
@@ -109,9 +109,3 @@ pub const ERAVM_ADDRESS_DECOMMIT: u16 = 0xFFDD;
 
 /// The corresponding simulation predefined address.
 pub const ERAVM_ADDRESS_ACTIVE_PTR_LOAD_DECOMMIT: u16 = 0xFFDC;
-
-/// The corresponding simulation predefined address.
-pub const ERAVM_ADDRESS_TRANSIENT_STORAGE_LOAD: u16 = 0xFFDB;
-
-/// The corresponding simulation predefined address.
-pub const ERAVM_ADDRESS_TRANSIENT_STORAGE_STORE: u16 = 0xFFDA;


### PR DESCRIPTION
# What ❔

Removes transient storage simulations.

## Why ❔

They are now included into Solidity IRs since solc v0.8.24.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
