### PR TITLE
ci: add cross dependency testing workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: License and secrets check
+name: Build and test
 
 on:
   pull_request:
@@ -26,5 +26,21 @@ jobs:
 
   # Check for secrets leak in the repository
   secrets-scanner:
-    uses: matter-labs/era-compiler-ci/.github/workflows/secrets-scanner.yaml@main
+    uses: matter-labs/era-compiler-ci/.github/workflows/secrets-scanner.yaml@v1
     secrets: inherit
+
+  build-test:
+    runs-on: matterlabs-ci-runner-high-performance
+    container:
+      image: ghcr.io/matter-labs/zksync-llvm-runner:latest
+    steps:
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Run unit tests
+        uses: matter-labs/era-compiler-ci/.github/actions/rust-unit-tests@v1
+        with:
+          target: "x86_64-unknown-linux-gnu"
+          enable-coverage: true
+          coverage-token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/dependency_check.yaml
+++ b/.github/workflows/dependency_check.yaml
@@ -1,0 +1,105 @@
+name: Dependency check
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  define-dependencies:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.ZKSYNC_DISPATCH_TOKEN }}
+    outputs:
+      dependencies_list: ${{ steps.define-dependencies.outputs.dependencies_list }}
+      zksolc_branch: ${{ steps.target-branches.outputs.zksolc_branch }}
+      zkvyper_branch: ${{ steps.target-branches.outputs.zkvyper_branch }}
+      llvm_context_branch: ${{ steps.target-branches.outputs.llvm_context_branch }}
+    steps:
+      - name: Define dependencies
+        id: define-dependencies
+        env:
+          POSSIBLE_DEPS: "matter-labs/era-compiler-common matter-labs/era-compiler-llvm-context matter-labs-forks/inkwell matter-labs-forks/llvm-sys.rs"
+        shell: bash -x {0}
+        run: |
+          DEPENDENCIES_LIST=""
+          for DEP in ${POSSIBLE_DEPS}; do
+            # Check if the branch of this repository dependency exists in the other repositories
+            # and if so, add it to the list of the dependencies that should be updated on the target repository
+            if [ $(gh api "/repos/${DEP}/branches/${{ github.head_ref }}" > /dev/null 2>&1; echo $?) -eq 0 ]; then
+              DEPENDENCIES_LIST="${DEPENDENCIES_LIST} ${DEP}"
+            fi
+          done
+          echo "dependencies_list=$(echo ${DEPENDENCIES_LIST} | sed 's/^[[:space:]]*//g')" | tee -a "${GITHUB_OUTPUT}"
+
+      - name: Define target branch
+        id: target-branches
+        env:
+          ERA_SOLIDITY_REPO: matter-labs/era-compiler-solidity
+          ERA_VYPER_REPO: matter-labs/era-compiler-vyper
+          ERA_LLVM_CONTEXT_REPO: matter-labs/era-compiler-llvm-context
+        shell: bash -x {0}
+        run: |
+          if [ $(gh api "/repos/${ERA_SOLIDITY_REPO}/branches/${{ github.head_ref }}" > /dev/null 2>&1; echo $?) -eq 0 ]; then
+            echo "zksolc_branch=${{ github.head_ref }}" | tee -a "${GITHUB_OUTPUT}"
+          fi
+          if [ $(gh api "/repos/${ERA_VYPER_REPO}/branches/${{ github.head_ref }}" > /dev/null 2>&1; echo $?) -eq 0 ]; then
+            echo "zkvyper_branch=${{ github.head_ref }}" | tee -a "${GITHUB_OUTPUT}"
+          fi
+          if [ $(gh api "/repos/${ERA_LLVM_CONTEXT_REPO}/branches/${{ github.head_ref }}" > /dev/null 2>&1; echo $?) -eq 0 ]; then
+            echo "llvm_context_branch=${{ github.head_ref }}" | tee -a "${GITHUB_OUTPUT}"
+          fi
+
+  check-llvm-context:
+    needs: define-dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: matter-labs
+          repo: era-compiler-llvm-context
+          workflow_file_name: dependencies.yaml
+          github_token: ${{ secrets.ZKSYNC_DISPATCH_TOKEN }}
+          ref: ${{ needs.define-dependencies.outputs.llvm_context_branch || 'main' }}
+          wait_interval: 30
+          client_payload: '{ "dependencies_list": "${{ needs.define-dependencies.outputs.dependencies_list }}", "dependencies_branch": "${{ github.head_ref }}" }'
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+
+  check-zksolc:
+    needs: define-dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: matter-labs
+          repo: era-compiler-solidity
+          workflow_file_name: dependencies.yaml
+          github_token: ${{ secrets.ZKSYNC_DISPATCH_TOKEN }}
+          ref: ${{ needs.define-dependencies.outputs.zksolc_branch || 'main' }}
+          wait_interval: 30
+          client_payload: '{ "dependencies_list": "${{ needs.define-dependencies.outputs.dependencies_list }}", "dependencies_branch": "${{ github.head_ref }}" }'
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true
+
+  check-zkvyper:
+    needs: define-dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: convictional/trigger-workflow-and-wait@v1.6.1
+        with:
+          owner: matter-labs
+          repo: era-compiler-vyper
+          github_token: ${{ secrets.ZKSYNC_DISPATCH_TOKEN }}
+          workflow_file_name: dependencies.yaml
+          ref: ${{ needs.define-dependencies.outputs.zkvyper_branch || 'main' }}
+          wait_interval: 30
+          client_payload: '{ "dependencies_list": "${{ needs.define-dependencies.outputs.dependencies_list }}", "dependencies_branch": "${{ github.head_ref }}" }'
+          propagate_failure: true
+          trigger_workflow: true
+          wait_workflow: true

--- a/era-compiler-common/src/hash/mod.rs
+++ b/era-compiler-common/src/hash/mod.rs
@@ -147,7 +147,7 @@ mod tests {
     fn ipfs_cbor() {
         assert_eq!(
             hex::encode(super::Hash::ipfs("zksync".as_bytes()).as_cbor_bytes()),
-            "a2646970667358221220a3e4a4b11362b17e7294afb3048e97a6cb024209f236d7388ef55476192413bf002a"
+            "a1646970667358221220a3e4a4b11362b17e7294afb3048e97a6cb024209f236d7388ef55476192413bf002a"
         );
     }
 }


### PR DESCRIPTION
# What ❔

Add cross-dependency testing workflow.
With each PR, we'll be also checking the following repositories:
* [x] `era-compiler-llvm-context`
* [x] `era-compiler-solidity`
* [x] `era-compiler-vyper`
are building and tests are passing _with custom `era-compiler-common` version_ from the testing PR.

Additionally, if the branch with the same name exist in any of the dependencies (e.g. `era-compiler-llvm-context`, or `llvm-sys`, or `inkwell`) it will be taken instead of the default dependency.

<img width="625" alt="image" src="https://github.com/user-attachments/assets/35ab5be2-9e36-474d-97ef-9925620449bf">


<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To allow cross-testing common dependencies without requirements to create multiple PRs in various repositories.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
