### PR TITLE
fix: improve logging, rename binary to executable

### DIFF
--- a/era-compiler-downloader/src/config/executable/mod.rs
+++ b/era-compiler-downloader/src/config/executable/mod.rs
@@ -1,5 +1,5 @@
 //!
-//! The compiler downloader binary config.
+//! The compiler downloader executable config.
 //!
 
 pub mod protocol;
@@ -9,16 +9,16 @@ use serde::Deserialize;
 use self::protocol::Protocol;
 
 ///
-/// The compiler downloader binary config.
+/// The compiler downloader executable config.
 ///
 #[derive(Debug, Deserialize)]
-pub struct Binary {
-    /// Whether downloading the binary is enabled.
+pub struct Executable {
+    /// Whether downloading the executable is enabled.
     pub is_enabled: bool,
     /// The downloading protocol.
     pub protocol: Protocol,
     /// The downloaded data source.
     pub source: String,
-    /// The downloaded binary file destination.
+    /// The downloaded executable file destination.
     pub destination: String,
 }

--- a/era-compiler-downloader/src/config/executable/protocol.rs
+++ b/era-compiler-downloader/src/config/executable/protocol.rs
@@ -1,11 +1,11 @@
 //!
-//! The compiler downloader binary download protocol.
+//! The compiler downloader executable download protocol.
 //!
 
 use serde::Deserialize;
 
 ///
-/// The compiler downloader binary download protocol.
+/// The compiler downloader executable download protocol.
 ///
 #[derive(Debug, Deserialize)]
 #[allow(clippy::upper_case_acronyms)]

--- a/era-compiler-downloader/src/config/mod.rs
+++ b/era-compiler-downloader/src/config/mod.rs
@@ -2,15 +2,15 @@
 //! The compiler downloader config.
 //!
 
-pub mod binary;
 pub(crate) mod compiler_list;
+pub mod executable;
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 
 use serde::Deserialize;
 
-use self::binary::Binary;
+use self::executable::Executable;
 
 ///
 /// The compiler downloader config.
@@ -18,7 +18,7 @@ use self::binary::Binary;
 #[derive(Debug, Deserialize)]
 pub struct Config {
     /// The compiler binaries to download.
-    pub binaries: BTreeMap<String, Binary>,
+    pub binaries: BTreeMap<String, Executable>,
     /// The compiler platform directory names.
     pub platforms: Option<HashMap<String, String>>,
 }


### PR DESCRIPTION
# What ❔

Adds logs when downloading is skipped for some reason.

## Why ❔

Was unclear for some cases of `era-solidity` CI.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
