### PR TITLE
fix: set full semver for dependencies

### DIFF
--- a/era-compiler-common/Cargo.toml
+++ b/era-compiler-common/Cargo.toml
@@ -10,13 +10,13 @@ edition.workspace = true
 doctest = false
 
 [dependencies]
-anyhow = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = { version = "1.0", features = [ "arbitrary_precision", "unbounded_depth" ] }
-serde_stacker = "0.1"
-serde_arrays = "0.1"
+anyhow = "=1.0.89"
+serde = { version = "=1.0.210", features = ["derive"] }
+serde_json = { version = "=1.0.128", features = [ "arbitrary_precision", "unbounded_depth" ] }
+serde_stacker = "=0.1.11"
+serde_arrays = "=0.1.0"
 
-sha3 = "0.10"
-hex = "0.4"
-ipfs-hasher = "0.13"
-base58 = "0.2"
+sha3 = "=0.10.8"
+hex = "=0.4.3"
+ipfs-hasher = "=0.13.0"
+base58 = "=0.2.0"


### PR DESCRIPTION
# What ❔

Adds the revision part for semver of all dependencies.

## Why ❔

`cargo update` will become more resilient.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
