### PR TITLE
fix: downloading on Windows via compiler bin JSON

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ authors = [
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
+version = "1.5.0"

--- a/era-compiler-common/Cargo.toml
+++ b/era-compiler-common/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "era-compiler-common"
-version = "1.5.0"
 description = "Shared constants of the ZKsync compilers"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
+version.workspace = true
 
 [lib]
 doctest = false

--- a/era-compiler-downloader/Cargo.toml
+++ b/era-compiler-downloader/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "era-compiler-downloader"
-version = "0.1.0"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
+version.workspace = true
 
 [dependencies]
-colored = "2.1.0"
-reqwest = { version = "0.11", features = ["blocking", "json"] }
-serde = { version = "1.0", "features" = [ "derive" ] }
-anyhow = "1.0"
-serde_json = { version = "1.0", features = [ "arbitrary_precision" ] }
+anyhow = "=1.0.89"
+colored = "=2.1.0"
+serde = { version = "=1.0.210", "features" = [ "derive" ] }
+serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
+
+reqwest = { version = "=0.11.27", features = ["blocking", "json"] }
 
 # Musl requires explicit openssl dependency
 [target.'cfg(target_env = "musl")'.dependencies]
-openssl = { version = "0.10", features = ["vendored"] }
+openssl = { version = "=0.10.68", features = ["vendored"] }

--- a/era-compiler-downloader/src/config/compiler_list.rs
+++ b/era-compiler-downloader/src/config/compiler_list.rs
@@ -7,12 +7,11 @@ use std::path::Path;
 use std::str::FromStr;
 
 use colored::Colorize;
-use serde::Deserialize;
 
 ///
 /// The compiler JSON list metadata.
 ///
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct CompilerList {
     /// The collection of compiler releases.
     pub releases: BTreeMap<String, String>,

--- a/era-compiler-downloader/src/config/executable/mod.rs
+++ b/era-compiler-downloader/src/config/executable/mod.rs
@@ -4,14 +4,12 @@
 
 pub mod protocol;
 
-use serde::Deserialize;
-
 use self::protocol::Protocol;
 
 ///
 /// The compiler downloader executable config.
 ///
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct Executable {
     /// Whether downloading the executable is enabled.
     pub is_enabled: bool,

--- a/era-compiler-downloader/src/config/executable/protocol.rs
+++ b/era-compiler-downloader/src/config/executable/protocol.rs
@@ -2,12 +2,10 @@
 //! The compiler downloader executable download protocol.
 //!
 
-use serde::Deserialize;
-
 ///
 /// The compiler downloader executable download protocol.
 ///
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 #[allow(clippy::upper_case_acronyms)]
 pub enum Protocol {
     /// The local file copy.

--- a/era-compiler-downloader/src/config/mod.rs
+++ b/era-compiler-downloader/src/config/mod.rs
@@ -2,24 +2,23 @@
 //! The compiler downloader config.
 //!
 
-pub(crate) mod compiler_list;
+pub mod compiler_list;
 pub mod executable;
 
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-
-use serde::Deserialize;
 
 use self::executable::Executable;
 
 ///
 /// The compiler downloader config.
 ///
-#[derive(Debug, Deserialize)]
+#[derive(Debug, serde::Deserialize)]
 pub struct Config {
-    /// The compiler binaries to download.
-    pub binaries: BTreeMap<String, Executable>,
-    /// The compiler platform directory names.
+    /// Compiler executables to download.
+    #[serde(rename = "binaries")]
+    pub executables: BTreeMap<String, Executable>,
+    /// Compiler platform directory names.
     pub platforms: Option<HashMap<String, String>>,
 }
 

--- a/era-compiler-downloader/src/lib.rs
+++ b/era-compiler-downloader/src/lib.rs
@@ -1,4 +1,8 @@
-mod config;
+//!
+//! The compiler downloader config.
+//!
+
+pub(crate) mod config;
 
 #[cfg(target_family = "unix")]
 use std::os::unix::fs::PermissionsExt;
@@ -40,79 +44,65 @@ impl Downloader {
     ///
     pub fn download(mut self, config_path: &Path) -> anyhow::Result<Config> {
         let config_file = std::fs::File::open(config_path).map_err(|error| {
-            anyhow::anyhow!(
-                "Binaries download config {:?} opening error: {}",
-                config_path,
-                error
-            )
+            anyhow::anyhow!("Executable downloader config {config_path:?} opening error: {error}")
         })?;
         let config_reader = std::io::BufReader::new(config_file);
         let config: Config = serde_json::from_reader(config_reader).map_err(|error| {
-            anyhow::anyhow!(
-                "Binaries download config {:?} parsing error: {}",
-                config_path,
-                error
-            )
+            anyhow::anyhow!("Executable downloader config {config_path:?} parsing error: {error}")
         })?;
 
         let platform_directory = config.get_remote_platform_directory()?;
 
-        for (version, executable) in config.binaries.iter() {
+        for (version, executable) in config.executables.iter() {
             if !executable.is_enabled {
                 continue;
             }
 
-            let source_path = executable
+            let mut source_path = executable
                 .source
                 .replace("${PLATFORM}", platform_directory.as_str())
-                .replace("${VERSION}", version.as_str())
-                + (std::env::consts::EXE_SUFFIX);
+                .replace("${VERSION}", version.as_str());
 
             let destination_path = executable
                 .destination
                 .replace("${VERSION}", version.as_str());
             let destination_path = PathBuf::from_str(
-                format!("{}{}", destination_path, std::env::consts::EXE_SUFFIX).as_str(),
+                format!("{destination_path}{}", std::env::consts::EXE_SUFFIX).as_str(),
             )
             .map_err(|_| {
-                anyhow::anyhow!("Executable `{}` destination is invalid", destination_path)
+                anyhow::anyhow!("Executable `{destination_path}` destination is invalid")
             })?;
 
             let data = match executable.protocol {
                 Protocol::File => {
+                    source_path += std::env::consts::EXE_SUFFIX;
                     if source_path == destination_path.to_string_lossy() {
                         println!(
-                            "    {} executable {:?}. The source and destination are the same.",
+                            "    {} executable {destination_path:?}. The source and destination are the same.",
                             "Skipping".bright_green().bold(),
-                            destination_path,
                         );
                         continue;
                     }
 
                     println!(
-                        "     {} executable `{}` => {:?}",
+                        "     {} executable `{source_path}` => {destination_path:?}",
                         "Copying".bright_green().bold(),
-                        source_path,
-                        destination_path,
                     );
 
                     std::fs::copy(source_path.as_str(), executable.destination.as_str()).map_err(
                         |error| {
-                            anyhow::anyhow!(
-                                "Executable {:?} copying error: {}",
-                                source_path.as_str(),
-                                error
-                            )
+                            anyhow::anyhow!("Executable {source_path:?} copying error: {error}",)
                         },
                     )?;
                     continue;
                 }
                 Protocol::HTTPS => {
+                    source_path += std::env::consts::EXE_SUFFIX;
+
                     if destination_path.exists() {
                         println!(
-                            "    {} executable {:?}. Already exists.",
+                            "    {} executable {destination_path:?}. Already exists.",
                             "Skipping".bright_green().bold(),
-                            destination_path,
                         );
                         continue;
                     }
@@ -120,19 +110,16 @@ impl Downloader {
                     let source_url =
                         reqwest::Url::from_str(source_path.as_str()).expect("Always valid");
                     println!(
-                        " {} executable `{}` => {:?}",
+                        " {} executable `{source_url}` => {destination_path:?}",
                         "Downloading".bright_green().bold(),
-                        source_url,
-                        destination_path,
                     );
                     self.http_client.get(source_url).send()?.bytes()?
                 }
                 Protocol::CompilerBinList => {
                     if destination_path.exists() {
                         println!(
-                            "    {} executable {:?}. Already exists.",
+                            "    {} executable {destination_path:?}. Already exists.",
                             "Skipping".bright_green().bold(),
-                            destination_path,
                         );
                         continue;
                     }
@@ -150,10 +137,17 @@ impl Downloader {
                         match compiler_list.releases.get(version.to_string().as_str()) {
                             Some(source_executable_name) => source_executable_name,
                             None => anyhow::bail!(
-                                "Executable for version v{} not found in the compiler JSON list",
-                                version
-                            ),
+                            "Executable for version v{version} not found in the compiler JSON list",
+                        ),
                         };
+                    #[cfg(target_os = "windows")]
+                    if !source_executable_name.ends_with(std::env::consts::EXE_SUFFIX) {
+                        println!(
+                            "    {} downloading {source_executable_name:?}. Not an executable file.",
+                            "Skipping".bright_green().bold(),
+                        );
+                        continue;
+                    }
                     let mut source_path = compiler_list_path;
                     source_path.pop();
                     source_path.push(source_executable_name);
@@ -162,10 +156,8 @@ impl Downloader {
                         reqwest::Url::from_str(source_path.to_str().expect("Always valid"))
                             .expect("Always valid");
                     println!(
-                        " {} executable `{}` => {:?}",
+                        " {} executable `{source_url}` => {destination_path:?}",
                         "Downloading".bright_green().bold(),
-                        source_url,
-                        destination_path,
                     );
                     self.http_client.get(source_url).send()?.bytes()?
                 }


### PR DESCRIPTION
# What ❔

Fixes downloading `solc` executables on Windows via compiler bin JSON.

## Why ❔

An `*.exe` suffix was mistakenly added to `list.json` files.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
