### PR TITLE
chore: move contract code segment to this crate

### DIFF
--- a/era-compiler-common/Cargo.toml
+++ b/era-compiler-common/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "era-compiler-common"
-description = "Shared constants of the ZKsync compilers"
 authors.workspace = true
 license.workspace = true
 edition.workspace = true
 version.workspace = true
+description = "Shared constants of the ZKsync compilers"
 
 [lib]
 doctest = false

--- a/era-compiler-common/src/code_segment.rs
+++ b/era-compiler-common/src/code_segment.rs
@@ -1,0 +1,31 @@
+//!
+//! The contract code segment.
+//!
+
+///
+/// The contract code segment.
+///
+/// On EraVM, the segments do not represent any entities in the final bytecode, but this separation is present
+/// in IRs used for lowering.
+///
+/// On EVM, the segments represent deploy and runtime code segments without changes.
+///
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "camelCase")]
+pub enum CodeSegment {
+    /// The deploy code segment.
+    Deploy,
+    /// The runtime code segment.
+    Runtime,
+}
+
+impl std::fmt::Display for CodeSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Deploy => write!(f, "deploy"),
+            Self::Runtime => write!(f, "runtime"),
+        }
+    }
+}

--- a/era-compiler-common/src/lib.rs
+++ b/era-compiler-common/src/lib.rs
@@ -5,6 +5,7 @@
 pub(crate) mod base;
 pub(crate) mod bit_length;
 pub(crate) mod byte_length;
+pub(crate) mod code_segment;
 pub(crate) mod contract_name;
 pub(crate) mod eravm;
 pub(crate) mod evm_version;
@@ -17,6 +18,7 @@ pub(crate) mod utils;
 pub use self::base::*;
 pub use self::bit_length::*;
 pub use self::byte_length::*;
+pub use self::code_segment::CodeSegment;
 pub use self::contract_name::ContractName;
 pub use self::eravm::address::*;
 pub use self::evm_version::EVMVersion;

--- a/era-compiler-downloader/Cargo.toml
+++ b/era-compiler-downloader/Cargo.toml
@@ -4,6 +4,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 version.workspace = true
+description = "Downloader for dependencies of the ZKsync compilers"
 
 [dependencies]
 anyhow = "=1.0.89"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.80.1"
+channel = "1.82.0"


### PR DESCRIPTION
# What ❔

Moves contract code segment from [era-compiler-llvm-context](https://github.com/matter-labs/era-compiler-llvm-context).

## Why ❔

It is required for some LLVM-independent crates such as the upcoming era-solc client.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
