### PR TITLE
ci: use default ci github token for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,5 +14,5 @@ jobs:
   release:
     uses: matter-labs/era-compiler-ci/.github/workflows/release-plz.yaml@v1
     secrets:
-      gh_token: ${{ secrets.RELEASE_TOKEN }}
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
       cargo_registry_token: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
# What ❔

Use default `GITHUB_TOKEN` generated by GH actions.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

ZKsync bot has not correct permissions set.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
