### PR TITLE
feat: add binary object format

### DIFF
--- a/era-compiler-common/src/lib.rs
+++ b/era-compiler-common/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod evm_version;
 pub(crate) mod exit_code;
 pub(crate) mod extension;
 pub(crate) mod hash;
+pub(crate) mod object_format;
 pub(crate) mod target;
 pub(crate) mod utils;
 
@@ -26,5 +27,6 @@ pub use self::exit_code::*;
 pub use self::extension::*;
 pub use self::hash::r#type::Type as HashType;
 pub use self::hash::Hash;
+pub use self::object_format::ObjectFormat;
 pub use self::target::Target;
 pub use self::utils::*;

--- a/era-compiler-common/src/object_format.rs
+++ b/era-compiler-common/src/object_format.rs
@@ -1,0 +1,45 @@
+//!
+//! The binary object format.
+//!
+
+use std::str::FromStr;
+
+///
+/// The binary object format.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ObjectFormat {
+    /// ELF object format.
+    ELF,
+    /// Raw binary data.
+    Raw,
+}
+
+impl FromStr for ObjectFormat {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "elf" => Ok(Self::ELF),
+            "raw" => Ok(Self::Raw),
+            _ => anyhow::bail!(
+                "Unknown object format: {value}. Supported formats: {}",
+                vec![Self::ELF, Self::Raw]
+                    .into_iter()
+                    .map(|format| format.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ),
+        }
+    }
+}
+
+impl std::fmt::Display for ObjectFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ELF => write!(f, "elf"),
+            Self::Raw => write!(f, "raw"),
+        }
+    }
+}


### PR DESCRIPTION
# What ❔

Adds the binary object format type.

## Why ❔

It is used by a lot of linker facilities throughout the toolchain.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
