### PR TITLE
chore: bump serde json dep

### DIFF
--- a/era-compiler-common/Cargo.toml
+++ b/era-compiler-common/Cargo.toml
@@ -12,7 +12,7 @@ doctest = false
 [dependencies]
 anyhow = "=1.0.89"
 serde = { version = "=1.0.210", features = ["derive"] }
-serde_json = { version = "=1.0.128", features = [ "arbitrary_precision", "unbounded_depth" ] }
+serde_json = { version = "=1.0.133", features = [ "arbitrary_precision", "unbounded_depth" ] }
 serde_stacker = "=0.1.11"
 serde_arrays = "=0.1.0"
 

--- a/era-compiler-downloader/Cargo.toml
+++ b/era-compiler-downloader/Cargo.toml
@@ -10,7 +10,7 @@ description = "Downloader for dependencies of the ZKsync compilers"
 anyhow = "=1.0.89"
 colored = "=2.1.0"
 serde = { version = "=1.0.210", "features" = [ "derive" ] }
-serde_json = { version = "=1.0.128", features = [ "arbitrary_precision" ] }
+serde_json = { version = "=1.0.133", features = [ "arbitrary_precision" ] }
 
 reqwest = { version = "=0.11.27", features = ["blocking", "json"] }
 


### PR DESCRIPTION
# What ❔

- Bumps `serde_json` so https://github.com/matter-labs/era-compiler-solidity may be used as dependency in `foundry-zksync`
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

- `foundry-zksync` uses `1.0.133`
<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
