### PR TITLE
feat(evm): add remaining file extensions that mimic solc

### DIFF
--- a/era-compiler-common/src/extension.rs
+++ b/era-compiler-common/src/extension.rs
@@ -49,3 +49,18 @@ pub static EXTENSION_ERAVM_ASSEMBLY: &str = "zasm";
 
 /// The EraVM bytecode file extension.
 pub static EXTENSION_ERAVM_BINARY: &str = "zbin";
+
+/// The Solidity AST file extension.
+pub static EXTENSION_SOLIDITY_AST: &str = "ast";
+
+/// The Solidity ABI file extension.
+pub static EXTENSION_SOLIDITY_ABI: &str = "abi";
+
+/// The Solidity function signatures file extension.
+pub static EXTENSION_SOLIDITY_SIGNATURES: &str = "signatures";
+
+/// The Solidity developer documentation file extension.
+pub static EXTENSION_SOLIDITY_DOCDEV: &str = "docdev";
+
+/// The Solidity user documentation file extension.
+pub static EXTENSION_SOLIDITY_DOCUSER: &str = "docuser";

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.85.1"
+channel = "1.88.0"


### PR DESCRIPTION
# What ❔

Adds missing file extensions that `solc` produces.

## Why ❔

For now they've been hardcoded in `solx`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
